### PR TITLE
FIX: Script would save output files outside 'output' folder on non-Windows OS

### DIFF
--- a/func/anilist_getMedia.py
+++ b/func/anilist_getMedia.py
@@ -17,11 +17,11 @@ def getMediaEntries(mediaType, accessToken, userID, username, filepath, entryLog
 
     # Declare filepaths
     if mediaType == "ANIME":
-        outputMedia = os.path.join(filepath, "output\\anime_" + datetime.now().strftime("%Y-%m-%d") + ".json")
-        xmlMedia = os.path.join(filepath, "output\\anime_" + datetime.now().strftime("%Y-%m-%d") + ".xml")
+        outputMedia = os.path.join(filepath, "output", "anime_" + datetime.now().strftime("%Y-%m-%d") + ".json")
+        xmlMedia = os.path.join(filepath, "output", "anime_" + datetime.now().strftime("%Y-%m-%d") + ".xml")
     else:
-        outputMedia = os.path.join(filepath, "output\\manga_" + datetime.now().strftime("%Y-%m-%d") + ".json")
-        xmlMedia = os.path.join(filepath, "output\\manga_" + datetime.now().strftime("%Y-%m-%d") + ".xml")
+        outputMedia = os.path.join(filepath, "output", "manga_" + datetime.now().strftime("%Y-%m-%d") + ".json")
+        xmlMedia = os.path.join(filepath, "output", "manga_" + datetime.now().strftime("%Y-%m-%d") + ".xml")
 
     # Check if not existing
     if not (os.path.exists(outputMedia)):

--- a/func/trim_list.py
+++ b/func/trim_list.py
@@ -19,7 +19,7 @@ def sort_byval(json):
 
 def trim_results(filepath, inputAnime, inputManga):
     # Declare filepaths
-    outputStats = os.path.join(filepath, "output\\animemanga_stats.txt")
+    outputStats = os.path.join(filepath, "output", "animemanga_stats.txt")
     outputAnime = inputAnime[:-5] + "_NotInMAL.json"
     outputManga = inputManga[:-5] + "_NotInMAL.json"
     # STATS variables

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ userID = 0
 # Output file names
 outputAnime = ""
 outputManga = ""
-entryLog = os.path.join(PROJECT_PATH, "output\\entries.log") # Log entries
+entryLog = os.path.join(PROJECT_PATH, "output", "entries.log") # Log entries
 
 # Create 'output' directory
 if not os.path.exists('output'):


### PR DESCRIPTION
The script uses multiple time backslash on path but it works only on windows therefore on any other OS the output would be saved as "output\anime. . ." in the AniPy folder instead of being saved as "anime. . ." in the output folder. 